### PR TITLE
Remove git alias from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Create a directory in which to keep the model configurations:
     cd ~/access-esm
     git clone https://github.com/coecms/access-esm
     cd access-esm
-    git co pre-industrial
+    git checkout pre-industrial
 
 We strongly recommend to switch to a new branch for the running of the model:
 


### PR DESCRIPTION
A `git co` was kept in the README. I believe it stands for `git checkout`